### PR TITLE
Use the proper automake variable for linking

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,3 @@
-AM_LDFLAGS = -lrt
 bin_PROGRAMS = mq
 mq_SOURCES = mq.c
+mq_LDADD = -lrt


### PR DESCRIPTION
The `_LDFLAGS` family of variables is not appropriate for specifying
libraries to link against, since libraries are (potentially)
order-dependent. That is, symbols referenced by an object file will
only be resolved by libraries that are specified *after* the object
file.

This has always been the case for static libraries, but it seems newer
toolchains also enforce order for shared libraries; at least with GCC
9.2.1 and GNU ld 2.33.1, this lead the build failing at the linker
stage, as described in issue #2.

Fixes: #2.