### PR TITLE
Support output without delimiter, call write in loop

### DIFF
--- a/src/mq.c
+++ b/src/mq.c
@@ -290,6 +290,7 @@ static void write_msg_with_delimiter(const struct arguments *args, uint8_t *buff
 			LOG_ERR("mq_receive error writing message: %s", strerror(errno));
         		exit(1);
         	} else {
+                        buffer = buffer + (size_t)messageWrittenBytes;
         		messageRemainingBytes = messageRemainingBytes - (size_t)messageWrittenBytes;
         	}
         } while (messageRemainingBytes > 0);


### PR DESCRIPTION
The `recv` subcommand has a mistake that can cause it to truncate messages when outputting them. It ignores error codes and doesn't call `write` in a loop to write out the entirety of the buffer. This PR fixes that mistake. Additionally, it adds support for a "no delimiter" option, selected with the character `x`.

I've not actually tested this yet, so don't merge this. I'm just planning on using this in a one-off script where the output is piped to `curl`, and I noticed that the output would occasionally be wrong.